### PR TITLE
#12 updating NSwag dependency to latest version

### DIFF
--- a/src/NSwag.Examples/NSwag.Examples.csproj
+++ b/src/NSwag.Examples/NSwag.Examples.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSwag.AspNetCore" Version="13.15.10" />
+    <PackageReference Include="NSwag.AspNetCore" Version="13.19.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This is probably the simplest approach I could come up with; you only need to update to this version if you need to `NSwag.AspNetCore.13.19.0`, for instance if you are using EF Core 7.