### PR TITLE
Adding support for multiple specific examples, filtering examples by request / response, filtering examples by response status code

### DIFF
--- a/samples/NSwagWithExamples/Models/Examples/PersonExample.cs
+++ b/samples/NSwagWithExamples/Models/Examples/PersonExample.cs
@@ -25,3 +25,17 @@ public class PersonExample : IExampleProvider<Person>
         };
     }
 }
+
+[ExampleAnnotation(ExampleType = ExampleType.Request)]
+public class PersonRequestExample : IExampleProvider<Person>
+{
+    public Person GetExample()
+    {
+        return new Person
+        {
+            Id = 1,
+            FirstName = "Fixed First Name",
+            LastName = "Fixed Last Name",
+        };
+    }
+}

--- a/src/NSwag.Examples/EndpointSpecificExampleAttribute.cs
+++ b/src/NSwag.Examples/EndpointSpecificExampleAttribute.cs
@@ -1,17 +1,29 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace NSwag.Examples;
 
-[AttributeUsage(AttributeTargets.Method)]
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
 public class EndpointSpecificExampleAttribute : Attribute
 {
-    public Type ExampleType { get; }
+    public IEnumerable<Type> ExampleTypes { get; }
 
-    public EndpointSpecificExampleAttribute(Type exampleType) {
+    public int ResponseStatusCode { get; set; }
+
+    public ExampleType ExampleType { get; set; } = ExampleType.Both;
+
+    public EndpointSpecificExampleAttribute(Type exampleType, params Type[] additionalExampleTypes)
+    {
         if (exampleType.GetInterfaces().All(i => i.IsGenericType && i.GetGenericTypeDefinition() != typeof(IExampleProvider<>)))
             throw new InvalidCastException($"Type {exampleType} does not implement {typeof(IExampleProvider<>)}.");
 
-        ExampleType = exampleType;
+        foreach (var additionalExampleType in additionalExampleTypes)
+        {
+            if (additionalExampleType.GetInterfaces().All(i => i.IsGenericType && i.GetGenericTypeDefinition() != typeof(IExampleProvider<>)))
+                throw new InvalidCastException($"Type {additionalExampleType} does not implement {typeof(IExampleProvider<>)}.");
+        }
+
+        ExampleTypes = additionalExampleTypes.Prepend(exampleType);
     }
 }

--- a/src/NSwag.Examples/ExampleAnnotationAttribute.cs
+++ b/src/NSwag.Examples/ExampleAnnotationAttribute.cs
@@ -6,4 +6,6 @@ namespace NSwag.Examples;
 public class ExampleAnnotationAttribute : Attribute
 {
     public string? Name { get; set; }
+
+    public ExampleType ExampleType { get; set; } = ExampleType.Both;
 }

--- a/src/NSwag.Examples/ExampleAnnotationAttribute.cs
+++ b/src/NSwag.Examples/ExampleAnnotationAttribute.cs
@@ -7,5 +7,7 @@ public class ExampleAnnotationAttribute : Attribute
 {
     public string? Name { get; set; }
 
+    public string? Description { get; set; }
+
     public ExampleType ExampleType { get; set; } = ExampleType.Both;
 }

--- a/src/NSwag.Examples/ExampleType.cs
+++ b/src/NSwag.Examples/ExampleType.cs
@@ -1,0 +1,8 @@
+namespace NSwag.Examples;
+
+public enum ExampleType
+{
+    Both,
+    Request,
+    Response,
+}

--- a/src/NSwag.Examples/ExamplesConverter.cs
+++ b/src/NSwag.Examples/ExamplesConverter.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -18,9 +19,9 @@ internal class ExamplesConverter
         return JToken.Parse(serializeObject);
     }
 
-    internal IDictionary<string, OpenApiExample> ToOpenApiExamplesDictionary(IEnumerable<KeyValuePair<string, object>> examples) {
+    internal IDictionary<string, OpenApiExample> ToOpenApiExamplesDictionary(IEnumerable<KeyValuePair<string, Tuple<object, string?>>> examples) {
         return examples.ToDictionary(
             example => example.Key,
-            example => new OpenApiExample { Value = SerializeExampleJson(example.Value) });
+            example => new OpenApiExample { Value = SerializeExampleJson(example.Value.Item1), Description = example.Value.Item2 });
     }
 }

--- a/src/NSwag.Examples/NSwag.Examples.csproj
+++ b/src/NSwag.Examples/NSwag.Examples.csproj
@@ -16,6 +16,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="NSwag.AspNetCore" Version="13.19.0"/>
+        <PackageReference Include="NSwag.AspNetCore" Version="13.19.0" />
     </ItemGroup>
 </Project>

--- a/src/NSwag.Examples/RequestBodyExampleProcessor.cs
+++ b/src/NSwag.Examples/RequestBodyExampleProcessor.cs
@@ -89,7 +89,7 @@ public class RequestBodyExampleProcessor : IOperationProcessor
 
     private IDictionary<string, OpenApiExample> GetExamples(SwaggerExampleProvider exampleProvider, Type? valueType, IEnumerable<Type> exampleTypes, ExampleType exampleType) {
         var providerValues = exampleProvider.GetProviderValues(valueType, exampleTypes, exampleType);
-        var openApiExamples = _examplesConverter.ToOpenApiExamplesDictionary(providerValues.Select((x, i) => new KeyValuePair<string, object>(x.Key ?? $"Example {i + 1}", x.Value)));
+        var openApiExamples = _examplesConverter.ToOpenApiExamplesDictionary(providerValues.Select((x, i) => new KeyValuePair<string, Tuple<object, string?>>(x.Key ?? $"Example {i + 1}", x.Value)));
         return openApiExamples;
     }
 

--- a/src/NSwag.Examples/RequestBodyExampleProcessor.cs
+++ b/src/NSwag.Examples/RequestBodyExampleProcessor.cs
@@ -37,8 +37,10 @@ public class RequestBodyExampleProcessor : IOperationProcessor
             if (!context.OperationDescription.Operation.RequestBody.Content.TryGetValue(MediaTypeName, out var mediaType))
                 continue;
 
-            var endpointSpecificExampleAttribute = context.MethodInfo.GetCustomAttribute<EndpointSpecificExampleAttribute?>();
-            SetExamples(GetExamples(exampleProvider, parameter.Key.ParameterType, endpointSpecificExampleAttribute?.ExampleType), mediaType);
+            var endpointSpecificExampleAttributes = context.MethodInfo.GetCustomAttributes<EndpointSpecificExampleAttribute>();
+            SetExamples(GetExamples(exampleProvider, parameter.Key.ParameterType, endpointSpecificExampleAttributes
+                .Where(x => x.ExampleType == ExampleType.Request || x.ExampleType == ExampleType.Both)
+                .SelectMany(x => x.ExampleTypes), ExampleType.Request), mediaType);
         }
     }
 
@@ -61,9 +63,12 @@ public class RequestBodyExampleProcessor : IOperationProcessor
             else if (attributesWithSameKey.Count == 0)
                 continue;
 
-            var endpointSpecificExampleAttribute = context.MethodInfo.GetCustomAttribute<EndpointSpecificExampleAttribute?>();
+            var endpointSpecificExampleAttributes = context.MethodInfo.GetCustomAttributes<EndpointSpecificExampleAttribute>();
             var valueType = attributesWithSameKey.FirstOrDefault()?.Type;
-            SetExamples(GetExamples(exampleProvider, valueType, endpointSpecificExampleAttribute?.ExampleType), mediaType);
+            SetExamples(GetExamples(exampleProvider, valueType, endpointSpecificExampleAttributes
+                .Where(x => x.ExampleType == ExampleType.Response || x.ExampleType == ExampleType.Both)
+                .Where(x => x.ResponseStatusCode != 0 || x.ResponseStatusCode == responseStatusCode)
+                .SelectMany(x => x.ExampleTypes), ExampleType.Response), mediaType);
         }
     }
 
@@ -82,8 +87,8 @@ public class RequestBodyExampleProcessor : IOperationProcessor
         }
     }
 
-    private IDictionary<string, OpenApiExample> GetExamples(SwaggerExampleProvider exampleProvider, Type? valueType, Type? exampleType) {
-        var providerValues = exampleProvider.GetProviderValues(valueType, exampleType);
+    private IDictionary<string, OpenApiExample> GetExamples(SwaggerExampleProvider exampleProvider, Type? valueType, IEnumerable<Type> exampleTypes, ExampleType exampleType) {
+        var providerValues = exampleProvider.GetProviderValues(valueType, exampleTypes, exampleType);
         var openApiExamples = _examplesConverter.ToOpenApiExamplesDictionary(providerValues.Select((x, i) => new KeyValuePair<string, object>(x.Key ?? $"Example {i + 1}", x.Value)));
         return openApiExamples;
     }

--- a/src/NSwag.Examples/SwaggerExampleProvider.cs
+++ b/src/NSwag.Examples/SwaggerExampleProvider.cs
@@ -16,7 +16,7 @@ internal class SwaggerExampleProvider
         _serviceProvider = serviceProvider;
     }
 
-    internal IEnumerable<KeyValuePair<string?, object>> GetProviderValues(Type? valueType, IEnumerable<Type> exampleTypes, ExampleType exampleType) {
+    internal IEnumerable<KeyValuePair<string?, Tuple<object, string?>>> GetProviderValues(Type? valueType, IEnumerable<Type> exampleTypes, ExampleType exampleType) {
         if (valueType == null)
             yield break;
 
@@ -26,7 +26,7 @@ internal class SwaggerExampleProvider
             var exampleAnnotationAttribute = providerType.GetCustomAttribute<ExampleAnnotationAttribute>();
             foreach (var example in providerServices.Select(x => ((dynamic)x).GetExample())) {
                 if (exampleAnnotationAttribute == null || exampleAnnotationAttribute.ExampleType == exampleType || exampleAnnotationAttribute.ExampleType == ExampleType.Both) {
-                    yield return new KeyValuePair<string?, object>(exampleAnnotationAttribute?.Name, example);
+                    yield return new KeyValuePair<string?, Tuple<object, string?>>(exampleAnnotationAttribute?.Name, new (example, exampleAnnotationAttribute?.Description));
                 }
             }
         }


### PR DESCRIPTION
I found it useful in my project to be able to expand this to support multiple specific examples, and needed to be able to select those examples by status code. (e.g. to pass the default examples for 200 OK, and several specific examples for 400 Bad Request.  I'm definitely open to any feedback or suggestions you have on these proposed changes.

- Adding support for multiple specific examples
- When using specific examples, allow that example to be filtered specifically to a request or response example
- When using specific examples, allow multiple examples
- When using specific examples, allow examples for various status codes
- Allow named examples to be restricted to either Request or Response