### PR TITLE
Make more amenable to Minimal api inc. http context

### DIFF
--- a/samples/NSwagWithExamples.sln
+++ b/samples/NSwagWithExamples.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NSwagWithExamples", "NSwagW
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NSwag.Examples", "..\src\NSwag.Examples\NSwag.Examples.csproj", "{AF90693D-AC3F-4AB1-9821-AF6D830C0932}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NSwagWithExamplesMinimal", "NSwagWithExamplesMinimal\NSwagWithExamplesMinimal.csproj", "{8130A917-642A-4CC2-B807-1D0119AC0FC0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{AF90693D-AC3F-4AB1-9821-AF6D830C0932}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AF90693D-AC3F-4AB1-9821-AF6D830C0932}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AF90693D-AC3F-4AB1-9821-AF6D830C0932}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8130A917-642A-4CC2-B807-1D0119AC0FC0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8130A917-642A-4CC2-B807-1D0119AC0FC0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8130A917-642A-4CC2-B807-1D0119AC0FC0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8130A917-642A-4CC2-B807-1D0119AC0FC0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/NSwagWithExamples/NSwagWithExamples.csproj
+++ b/samples/NSwagWithExamples/NSwagWithExamples.csproj
@@ -1,11 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <Version>1.0.14</Version>
-  </PropertyGroup>
-
+  
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
     <PackageReference Include="RandomNameGeneratorLibrary" Version="1.2.2" />

--- a/samples/NSwagWithExamplesMinimal/NSwagWithExamplesMinimal.csproj
+++ b/samples/NSwagWithExamplesMinimal/NSwagWithExamplesMinimal.csproj
@@ -1,11 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <Nullable>enable</Nullable>
-        <ImplicitUsings>enable</ImplicitUsings>
-    </PropertyGroup>
-
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.14"/>
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2"/>

--- a/samples/NSwagWithExamplesMinimal/NSwagWithExamplesMinimal.csproj
+++ b/samples/NSwagWithExamplesMinimal/NSwagWithExamplesMinimal.csproj
@@ -1,0 +1,97 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.14"/>
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2"/>
+        <PackageReference Include="RandomNameGeneratorLibrary" Version="1.2.2" />
+    </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NSwag.Examples\NSwag.Examples.csproj" />
+  </ItemGroup>
+
+    <ItemGroup>
+      <Compile Include="..\NSwagWithExamples\Models\City.cs">
+        <Link>Models\City.cs</Link>
+      </Compile>
+      <Compile Include="..\NSwagWithExamples\Models\CustomInternalError.cs">
+        <Link>Models\CustomInternalError.cs</Link>
+      </Compile>
+      <Compile Include="..\NSwagWithExamples\Models\CustomInternalErrorOnMethodLevel.cs">
+        <Link>Models\CustomInternalErrorOnMethodLevel.cs</Link>
+      </Compile>
+      <Compile Include="..\NSwagWithExamples\Models\Examples\BrnoExample.cs">
+        <Link>Models\Examples\BrnoExample.cs</Link>
+      </Compile>
+      <Compile Include="..\NSwagWithExamples\Models\Examples\CitiesExample.cs">
+        <Link>Models\Examples\CitiesExample.cs</Link>
+      </Compile>
+      <Compile Include="..\NSwagWithExamples\Models\Examples\CustomInternalErrorExample.cs">
+        <Link>Models\Examples\CustomInternalErrorExample.cs</Link>
+      </Compile>
+      <Compile Include="..\NSwagWithExamples\Models\Examples\CustomInternalErrorOnMethodLevelExample.cs">
+        <Link>Models\Examples\CustomInternalErrorOnMethodLevelExample.cs</Link>
+      </Compile>
+      <Compile Include="..\NSwagWithExamples\Models\Examples\IntExample.cs">
+        <Link>Models\Examples\IntExample.cs</Link>
+      </Compile>
+      <Compile Include="..\NSwagWithExamples\Models\Examples\Persons\PeopleExample.cs">
+        <Link>Models\Examples\Persons\PeopleExample.cs</Link>
+      </Compile>
+      <Compile Include="..\NSwagWithExamples\Models\Examples\Persons\PersonExamples.cs">
+        <Link>Models\Examples\Persons\PersonExamples.cs</Link>
+      </Compile>
+      <Compile Include="..\NSwagWithExamples\Models\Examples\Persons\Requests\PersonAge18Example.cs">
+        <Link>Models\Examples\Persons\Requests\PersonAge18Example.cs</Link>
+      </Compile>
+      <Compile Include="..\NSwagWithExamples\Models\Examples\Persons\Requests\PersonAge69Example.cs">
+        <Link>Models\Examples\Persons\Requests\PersonAge69Example.cs</Link>
+      </Compile>
+      <Compile Include="..\NSwagWithExamples\Models\Examples\Persons\Requests\PersonRequestExampleCindy.cs">
+        <Link>Models\Examples\Persons\Requests\PersonRequestExampleCindy.cs</Link>
+      </Compile>
+      <Compile Include="..\NSwagWithExamples\Models\Examples\Persons\Requests\PersonRequestExampleTom.cs">
+        <Link>Models\Examples\Persons\Requests\PersonRequestExampleTom.cs</Link>
+      </Compile>
+      <Compile Include="..\NSwagWithExamples\Models\Examples\Persons\Requests\PersonTextExample1.cs">
+        <Link>Models\Examples\Persons\Requests\PersonTextExample1.cs</Link>
+      </Compile>
+      <Compile Include="..\NSwagWithExamples\Models\Examples\Persons\Requests\PersonTextExample2.cs">
+        <Link>Models\Examples\Persons\Requests\PersonTextExample2.cs</Link>
+      </Compile>
+      <Compile Include="..\NSwagWithExamples\Models\Examples\Persons\Requests\PersonTextExample3.cs">
+        <Link>Models\Examples\Persons\Requests\PersonTextExample3.cs</Link>
+      </Compile>
+      <Compile Include="..\NSwagWithExamples\Models\Examples\PragueExample.cs">
+        <Link>Models\Examples\PragueExample.cs</Link>
+      </Compile>
+      <Compile Include="..\NSwagWithExamples\Models\Person.cs">
+        <Link>Models\Person.cs</Link>
+      </Compile>
+      <Compile Include="..\NSwagWithExamples\Models\Zoo\Animal.cs">
+        <Link>Models\Zoo\Animal.cs</Link>
+      </Compile>
+      <Compile Include="..\NSwagWithExamples\Models\Zoo\Examples\AnimalsExample.cs">
+        <Link>Models\Zoo\Examples\AnimalsExample.cs</Link>
+      </Compile>
+      <Compile Include="..\NSwagWithExamples\Models\Zoo\Examples\MonkeyExample.cs">
+        <Link>Models\Zoo\Examples\MonkeyExample.cs</Link>
+      </Compile>
+      <Compile Include="..\NSwagWithExamples\Models\Zoo\Examples\SlothExample.cs">
+        <Link>Models\Zoo\Examples\SlothExample.cs</Link>
+      </Compile>
+      <Compile Include="..\NSwagWithExamples\Models\Zoo\Monkey.cs">
+        <Link>Models\Zoo\Monkey.cs</Link>
+      </Compile>
+      <Compile Include="..\NSwagWithExamples\Models\Zoo\Sloth.cs">
+        <Link>Models\Zoo\Sloth.cs</Link>
+      </Compile>
+    </ItemGroup>
+
+</Project>

--- a/samples/NSwagWithExamplesMinimal/NSwagWithExamplesMinimal.http
+++ b/samples/NSwagWithExamplesMinimal/NSwagWithExamplesMinimal.http
@@ -1,0 +1,6 @@
+@NSwagWithExamplesMinimal_HostAddress = http://localhost:5200
+
+GET {{NSwagWithExamplesMinimal_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/samples/NSwagWithExamplesMinimal/Program.cs
+++ b/samples/NSwagWithExamplesMinimal/Program.cs
@@ -18,6 +18,7 @@ var app = builder.Build();
 
 app.MapGroup("/api")
     .MapCityApi()
+    .MapPeopleApi()
     .MapZooApi();
 
 app.UseHttpsRedirection();

--- a/samples/NSwagWithExamplesMinimal/Program.cs
+++ b/samples/NSwagWithExamplesMinimal/Program.cs
@@ -7,22 +7,14 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddSingleton<IPersonNameGenerator, PersonNameGenerator>();
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddControllers();
 builder.Services.AddExampleProviders(typeof(CitiesExample).Assembly);
 builder.Services.AddOpenApiDocument((settings, provider) =>
 {
-    settings.Title = "NSwag with examples";
+    settings.Title = "NSwag with minimal api examples";
     settings.AddExamples(provider);
 });
 
 var app = builder.Build();
-
-// Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
-{
-    app.UseOpenApi();
-    app.UseSwaggerUi();
-}
 
 app.MapGroup("/api")
     .MapCityApi()
@@ -30,6 +22,7 @@ app.MapGroup("/api")
 
 app.UseHttpsRedirection();
 
-
+app.UseOpenApi();
+app.UseSwaggerUi();
 
 app.Run();

--- a/samples/NSwagWithExamplesMinimal/Program.cs
+++ b/samples/NSwagWithExamplesMinimal/Program.cs
@@ -1,0 +1,35 @@
+using NSwag.Examples;
+using NSwagWithExamplesMinimal.Routes;
+using NSwagWithExamples.Models.Examples;
+using RandomNameGeneratorLibrary;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSingleton<IPersonNameGenerator, PersonNameGenerator>();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddControllers();
+builder.Services.AddExampleProviders(typeof(CitiesExample).Assembly);
+builder.Services.AddOpenApiDocument((settings, provider) =>
+{
+    settings.Title = "NSwag with examples";
+    settings.AddExamples(provider);
+});
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseOpenApi();
+    app.UseSwaggerUi();
+}
+
+app.MapGroup("/api")
+    .MapCityApi()
+    .MapZooApi();
+
+app.UseHttpsRedirection();
+
+
+
+app.Run();

--- a/samples/NSwagWithExamplesMinimal/Program.cs
+++ b/samples/NSwagWithExamplesMinimal/Program.cs
@@ -16,7 +16,7 @@ builder.Services.AddOpenApiDocument((settings, provider) =>
 
 var app = builder.Build();
 
-app.MapGroup("/api")
+app.MapGroup("/api/v1")
     .MapCityApi()
     .MapPeopleApi()
     .MapZooApi();

--- a/samples/NSwagWithExamplesMinimal/Properties/launchSettings.json
+++ b/samples/NSwagWithExamplesMinimal/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:59910",
+      "sslPort": 44349
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5200",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7035;http://localhost:5200",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/NSwagWithExamplesMinimal/Routes/CityRouteExtension.cs
+++ b/samples/NSwagWithExamplesMinimal/Routes/CityRouteExtension.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using NSwagWithExamples.Models;
+
+namespace NSwagWithExamplesMinimal.Routes;
+
+public static class CityRouteExtension
+{
+    public static RouteGroupBuilder MapCityApi(this RouteGroupBuilder endpoints)
+    {
+        var cities = endpoints.MapGroup("cities").WithTags("Cities");
+        cities.MapGet("", GetCities).WithName("Get cities");
+        cities.MapGet("{id:int}", GetCity).WithName("Get city");;
+        cities.MapDelete("{id:int}", DeleteCity).WithName("Delete city");;
+        return endpoints;
+    }
+    
+    private static Ok<List<City>> GetCities() => TypedResults.Ok(new List<City>());
+
+    private static Ok<City> GetCity([FromRoute] int id) => TypedResults.Ok(new City());
+
+    private static Ok DeleteCity([FromRoute] int id) => TypedResults.Ok();
+}

--- a/samples/NSwagWithExamplesMinimal/Routes/CityRouteExtension.cs
+++ b/samples/NSwagWithExamplesMinimal/Routes/CityRouteExtension.cs
@@ -9,9 +9,9 @@ public static class CityRouteExtension
     public static RouteGroupBuilder MapCityApi(this RouteGroupBuilder endpoints)
     {
         var cities = endpoints.MapGroup("cities").WithTags("Cities");
-        cities.MapGet("", GetCities).WithName("Get cities");
-        cities.MapGet("{id:int}", GetCity).WithName("Get city");;
-        cities.MapDelete("{id:int}", DeleteCity).WithName("Delete city");;
+        cities.MapGet("", GetCities).WithName("Get cities").WithOpenApi();
+        cities.MapGet("{id:int}", GetCity).WithName("Get city").WithOpenApi();
+        cities.MapDelete("{id:int}", DeleteCity).WithName("Delete city").WithOpenApi();
         return endpoints;
     }
     

--- a/samples/NSwagWithExamplesMinimal/Routes/CityRouteExtension.cs
+++ b/samples/NSwagWithExamplesMinimal/Routes/CityRouteExtension.cs
@@ -9,9 +9,9 @@ public static class CityRouteExtension
     public static RouteGroupBuilder MapCityApi(this RouteGroupBuilder endpoints)
     {
         var cities = endpoints.MapGroup("cities").WithTags("Cities");
-        cities.MapGet("", GetCities).WithName("Get cities").WithOpenApi();
-        cities.MapGet("{id:int}", GetCity).WithName("Get city").WithOpenApi();
-        cities.MapDelete("{id:int}", DeleteCity).WithName("Delete city").WithOpenApi();
+        cities.MapGet("", GetCities).WithName("Get cities");
+        cities.MapGet("{id:int}", GetCity).WithName("Get city");
+        cities.MapDelete("{id:int}", DeleteCity).WithName("Delete city");
         return endpoints;
     }
     

--- a/samples/NSwagWithExamplesMinimal/Routes/PeopleRouteExtension.cs
+++ b/samples/NSwagWithExamplesMinimal/Routes/PeopleRouteExtension.cs
@@ -1,0 +1,98 @@
+using System.Collections.Concurrent;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using NSwag.Examples;
+using NSwagWithExamples.Models;
+using NSwagWithExamples.Models.Examples.Persons.Requests;
+
+namespace NSwagWithExamplesMinimal.Routes;
+
+public static class PeopleRouteExtension    
+{
+    private static readonly ConcurrentDictionary<int, Person> People = new();
+    private static readonly object Lock = new();
+
+    private static void NewPerson(Person person)
+    {
+        lock (Lock)
+        {
+            person.Id = People.Keys.Count != 0 ? People.Keys.Max() + 1 : 1;
+            People.TryAdd(person.Id, person);
+        }
+    }
+
+    static PeopleRouteExtension()
+    {
+        NewPerson(new Person("Franta", "Jetel"));
+        NewPerson(new Person("Jára", "Cimrman"));
+        NewPerson(new Person("Jindra", "Hlaváček"));
+        NewPerson(new Person("Vilma", "Böhmová"));
+        NewPerson(new Person("Emanuel", "Pecháček"));
+        NewPerson(new Person("Inspektor", "Trachta"));
+        NewPerson(new Person("Inspektor", "Klečka"));
+        NewPerson(new Person("první", "podezřelý"));
+        NewPerson(new Person("druhý", "podezřelý"));
+        NewPerson(new Person("třetí", "podezřelý"));
+        NewPerson(new Person("čtvrtý", "podezřelý"));
+    }
+    
+    public static RouteGroupBuilder MapPeopleApi(this RouteGroupBuilder endpoints)
+    {
+        var people = endpoints.MapGroup("people").WithTags("People");
+        people.MapGet("", GetPeople).WithName("Get people");
+        people.MapPost("", CreatePerson).WithName("Create person");
+        people.MapGet("count", GetNumberOfPeople).WithName("Get number of people");
+        people.MapGet("{id:int}", GetPerson).WithName("Get person");
+        people.MapGet("{id:int}/age", GetPersonAge).WithName("Get persons age");
+        people.MapGet("{id:int}/birth", GetPersonBirth).WithName("Get persons birth");
+        people.MapPost("from-file", CreatePersonFromFile).WithName("Create person from file");
+        return endpoints;
+    }
+
+    [EndpointSpecificExample(typeof(PersonAge18Example), typeof(PersonAge69Example), ParameterName = "minAge",
+        ExampleType = ExampleType.Request)]
+    [EndpointSpecificExample(typeof(PersonTextExample1), typeof(PersonTextExample2), typeof(PersonTextExample3),
+        ParameterName = "searchText", ExampleType = ExampleType.Request)]
+    private static Ok<List<Person>> GetPeople([FromQuery] int? minAge = null, [FromQuery] string searchText = null)
+    {
+        if (minAge == null && string.IsNullOrEmpty(searchText))
+            return TypedResults.Ok(People.Values.ToList());
+
+        if (minAge == null)
+            return TypedResults.Ok(People.Values.Where(p =>
+                    $"{p.FirstName}~{p.LastName}".Contains(searchText, StringComparison.CurrentCultureIgnoreCase))
+                .ToList());
+
+        if (string.IsNullOrEmpty(searchText))
+            return TypedResults.Ok(People.Values.Where(p => p.Age >= minAge).ToList());
+
+        return TypedResults.Ok(People.Values.Where(p =>
+            p.Age >= minAge &&
+            $"{p.FirstName}~{p.LastName}".Contains(searchText, StringComparison.CurrentCultureIgnoreCase)).ToList());
+    }
+
+    private static Ok<int> GetNumberOfPeople() => TypedResults.Ok(People.Count);
+
+    private static Results<Ok<Person>, NotFound> GetPerson([FromRoute] int id) =>
+        People.TryGetValue(id, out var person) ? TypedResults.Ok(person) : TypedResults.NotFound();
+
+    private static Results<Ok<int>, NotFound> GetPersonAge([FromRoute] int id) =>
+        People.TryGetValue(id, out var person) ? TypedResults.Ok(person.Age) : TypedResults.NotFound();
+
+    private static Results<Ok<DateTime>, NotFound>  GetPersonBirth([FromRoute] int id) =>
+        People.TryGetValue(id, out var person) ? TypedResults.Ok(person.BirthDay) : TypedResults.NotFound();
+
+    private static Results<Ok<int>, BadRequest<string>> CreatePerson([FromBody] Person person)
+    {
+        if (person == null)
+            return TypedResults.BadRequest("{person} is null");
+
+        if (person.BirthDay.Year < 1800 || person.BirthDay > DateTime.Now)
+            return TypedResults.BadRequest($"BirthDay is out of range (1800/01/01..today)");
+
+        NewPerson(person);
+        return TypedResults.Ok(person.Id);
+    }
+
+    private static Ok CreatePersonFromFile([FromForm] IFormFile file) => TypedResults.Ok();
+}

--- a/samples/NSwagWithExamplesMinimal/Routes/ZooRouteExtension.cs
+++ b/samples/NSwagWithExamplesMinimal/Routes/ZooRouteExtension.cs
@@ -11,8 +11,8 @@ public static class ZooRouteExtension
     public static RouteGroupBuilder MapZooApi(this RouteGroupBuilder endpoints)
     {
         var zoos = endpoints.MapGroup("zoos").WithTags("Zoos");
-        zoos.MapGet("", GetAnimals).WithName("Get animals").WithOpenApi();
-        zoos.MapGet("{name}", GetAnimal).WithName("Get animal").WithOpenApi();
+        zoos.MapGet("", GetAnimals).WithName("Get animals");
+        zoos.MapGet("{name}", GetAnimal).WithName("Get animal");
         zoos.MapPost("adopt", Adopt).WithName("Adopt animal")
             .Accepts<Animal>(MediaTypeNames.Application.Json)
             .Produces(201);

--- a/samples/NSwagWithExamplesMinimal/Routes/ZooRouteExtension.cs
+++ b/samples/NSwagWithExamplesMinimal/Routes/ZooRouteExtension.cs
@@ -11,8 +11,8 @@ public static class ZooRouteExtension
     public static RouteGroupBuilder MapZooApi(this RouteGroupBuilder endpoints)
     {
         var zoos = endpoints.MapGroup("zoos").WithTags("Zoos");
-        zoos.MapGet("", GetAnimals).WithName("Get animals");
-        zoos.MapGet("{name}", GetAnimal).WithName("Get animal");
+        zoos.MapGet("", GetAnimals).WithName("Get animals").WithOpenApi();
+        zoos.MapGet("{name}", GetAnimal).WithName("Get animal").WithOpenApi();
         zoos.MapPost("adopt", Adopt).WithName("Adopt animal")
             .Accepts<Animal>(MediaTypeNames.Application.Json)
             .Produces(201);

--- a/samples/NSwagWithExamplesMinimal/Routes/ZooRouteExtension.cs
+++ b/samples/NSwagWithExamplesMinimal/Routes/ZooRouteExtension.cs
@@ -1,0 +1,32 @@
+using System.Net.Mime;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using NSwagWithExamples.Models.Zoo;
+using RandomNameGeneratorLibrary;
+
+namespace NSwagWithExamplesMinimal.Routes;
+
+public static class ZooRouteExtension
+{
+    public static RouteGroupBuilder MapZooApi(this RouteGroupBuilder endpoints)
+    {
+        var zoos = endpoints.MapGroup("zoos").WithTags("Zoos");
+        zoos.MapGet("", GetAnimals).WithName("Get animals");
+        zoos.MapGet("{name}", GetAnimal).WithName("Get animal");
+        zoos.MapPost("adopt", Adopt).WithName("Adopt animal")
+            .Accepts<Animal>(MediaTypeNames.Application.Json)
+            .Produces(201);
+        return endpoints;
+    }
+
+    private static Ok<Animal[]> GetAnimals() => TypedResults.Ok(Array.Empty<Animal>());
+    
+    private static Ok<Animal> GetAnimal([FromRoute] string name) => TypedResults.Ok(default(Animal));
+    
+    private static async Task<IResult> Adopt(HttpContext context, IPersonNameGenerator _)
+    {
+        var animal = await context.Request.ReadFromJsonAsync<Animal>();
+        if (animal == null) throw new InvalidOperationException("Could not deserialise animal");
+        return TypedResults.Created();
+    }
+}

--- a/samples/NSwagWithExamplesMinimal/Routes/ZooRouteExtension.cs
+++ b/samples/NSwagWithExamplesMinimal/Routes/ZooRouteExtension.cs
@@ -12,10 +12,10 @@ public static class ZooRouteExtension
     {
         var zoos = endpoints.MapGroup("zoos").WithTags("Zoos");
         zoos.MapGet("", GetAnimals).WithName("Get animals");
-        zoos.MapGet("{name}", GetAnimal).WithName("Get animal");
-        zoos.MapPost("adopt", Adopt).WithName("Adopt animal")
+        zoos.MapPost("", Adopt).WithName("Adopt animal")
             .Accepts<Animal>(MediaTypeNames.Application.Json)
-            .Produces(201);
+            .Produces(StatusCodes.Status201Created);
+        zoos.MapGet("{name}", GetAnimal).WithName("Get animal");
         return endpoints;
     }
 

--- a/samples/NSwagWithExamplesMinimal/appsettings.Development.json
+++ b/samples/NSwagWithExamplesMinimal/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/samples/NSwagWithExamplesMinimal/appsettings.json
+++ b/samples/NSwagWithExamplesMinimal/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/NSwag.Examples/NSwag.Examples.csproj
+++ b/src/NSwag.Examples/NSwag.Examples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
         <Version>1.0.14</Version>
         <Authors>Vaclav Novotny</Authors>
         <RepositoryUrl>https://github.com/vaclavnovotny/NSwag.Examples</RepositoryUrl>

--- a/src/NSwag.Examples/RequestBodyExampleProcessor.cs
+++ b/src/NSwag.Examples/RequestBodyExampleProcessor.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Mvc;
+#if NET6_0_OR_GREATER
+using Microsoft.AspNetCore.Http.Metadata;
+#endif
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSwag.Generation.AspNetCore;
@@ -39,16 +42,33 @@ public class RequestBodyExampleProcessor : IOperationProcessor
                 continue;
 
             var endpointSpecificExampleAttributes = context.MethodInfo.GetCustomAttributes<EndpointSpecificExampleAttribute>();
-            SetExamples(
-                GetExamples(
-                    exampleProvider, 
-                    parameter.Key.ParameterType, 
-                    endpointSpecificExampleAttributes
-                        .Where(x => x.ExampleType == ExampleType.Request || x.ExampleType == ExampleType.Both)
-                        .SelectMany(x => x.ExampleTypes), ExampleType.Request
+            var parameterType = parameter.Key?.ParameterType;
+
+#if NET6_0_OR_GREATER
+            if (parameterType is null && 
+                context is AspNetCoreOperationProcessorContext aspNetCoreOperationProcessorContext)
+            {
+                parameterType = aspNetCoreOperationProcessorContext.ApiDescription.ActionDescriptor.EndpointMetadata
+                    .OfType<IAcceptsMetadata>()
+                    .Where(metadata => metadata.ContentTypes.Contains(MediaTypeName))
+                    .Select(metadata => metadata.RequestType)
+                    .FirstOrDefault();
+            }
+#endif
+            
+            if (parameterType is not null)
+            {
+                SetExamples(
+                    GetExamples(
+                        exampleProvider, 
+                        parameterType, 
+                        endpointSpecificExampleAttributes
+                            .Where(x => x.ExampleType == ExampleType.Request || x.ExampleType == ExampleType.Both)
+                            .SelectMany(x => x.ExampleTypes), ExampleType.Request
                     ), 
-                mediaType
+                    mediaType
                 );
+            }
         }
     }
 

--- a/src/NSwag.Examples/RequestBodyExampleProcessor.cs
+++ b/src/NSwag.Examples/RequestBodyExampleProcessor.cs
@@ -72,27 +72,40 @@ public class RequestBodyExampleProcessor : IOperationProcessor
         }
     }
 
-    private void SetResponseExamples(OperationProcessorContext context, SwaggerExampleProvider exampleProvider) {
-        foreach (var response in context.OperationDescription.Operation.Responses) {
+    private void SetResponseExamples(OperationProcessorContext context, SwaggerExampleProvider exampleProvider)
+    {
+        foreach (var response in context.OperationDescription.Operation.Responses)
+        {
             if (!int.TryParse(response.Key, out var responseStatusCode))
                 continue;
 
             if (!response.Value.Content.TryGetValue(MediaTypeName, out var mediaType))
                 continue;
 
-            var attributesWithSameKey = GetAttributesWithSameStatusCode(context.MethodInfo, responseStatusCode);
+            var typesWithSameKey = GetResponseTypesWithSameStatusCode(context.MethodInfo, responseStatusCode);
 
             //get attributes from controller, in case when no attribute on action was found
-            if (!attributesWithSameKey.Any())
-                attributesWithSameKey = GetAttributesWithSameStatusCode(context.MethodInfo.DeclaringType, responseStatusCode);
+            if (!typesWithSameKey.Any() && context.MethodInfo.DeclaringType is { } declaringType)
+                typesWithSameKey = GetResponseTypesWithSameStatusCode(declaringType, responseStatusCode);
 
-            if (attributesWithSameKey.Count > 1)
-                _logger.LogWarning($"Multiple {nameof(ProducesResponseTypeAttribute)} defined for method {context.MethodInfo.Name}, selecting first.");
-            else if (attributesWithSameKey.Count == 0)
+#if NET6_0_OR_GREATER
+            if (!typesWithSameKey.Any() &&
+                context is AspNetCoreOperationProcessorContext aspNetCoreOperationProcessorContext)
+            {
+                typesWithSameKey = GetResponseTypesWithSameStatusCode(aspNetCoreOperationProcessorContext, responseStatusCode);
+            }
+#endif
+
+
+            if (typesWithSameKey.Count > 1)
+                _logger.LogWarning(
+                    $"Multiple {nameof(ProducesResponseTypeAttribute)} defined for method {context.MethodInfo.Name}, selecting first.");
+            else if (typesWithSameKey.Count == 0)
                 continue;
 
-            var endpointSpecificExampleAttributes = context.MethodInfo.GetCustomAttributes<EndpointSpecificExampleAttribute>();
-            var valueType = attributesWithSameKey.FirstOrDefault()?.Type;
+            var endpointSpecificExampleAttributes =
+                context.MethodInfo.GetCustomAttributes<EndpointSpecificExampleAttribute>();
+            var valueType = typesWithSameKey.FirstOrDefault();
             SetExamples(GetExamples(exampleProvider, valueType, endpointSpecificExampleAttributes
                 .Where(x => x.ExampleType == ExampleType.Response || x.ExampleType == ExampleType.Both)
                 .Where(x => x.ResponseStatusCode != 0 && x.ResponseStatusCode == responseStatusCode)
@@ -121,10 +134,24 @@ public class RequestBodyExampleProcessor : IOperationProcessor
         return openApiExamples;
     }
 
-    private static List<ProducesResponseTypeAttribute> GetAttributesWithSameStatusCode(MemberInfo memberInfo, int responseStatusCode) {
-        return memberInfo
+    private static List<Type> GetResponseTypesWithSameStatusCode(MemberInfo memberInfo, int responseStatusCode) =>
+        memberInfo
             .GetCustomAttributes<ProducesResponseTypeAttribute>(true)
-            .Where(x => x.StatusCode == responseStatusCode)
+            .Where(attribute => attribute.StatusCode == responseStatusCode)
+            .Select(attribute => attribute.Type)
             .ToList();
-    }
+
+#if NET6_0_OR_GREATER
+    private static List<Type> GetResponseTypesWithSameStatusCode(AspNetCoreOperationProcessorContext aspNetCoreOperationProcessorContext, int responseStatusCode) =>
+        aspNetCoreOperationProcessorContext
+            .ApiDescription
+            .ActionDescriptor
+            .EndpointMetadata
+            .OfType<IProducesResponseTypeMetadata>()
+            .Where(metadata => metadata.StatusCode == responseStatusCode
+                               && metadata.ContentTypes.Contains(MediaTypeName)
+                               && metadata.Type is not null)
+            .Select(metadata => metadata.Type!)
+            .ToList();
+#endif
 }


### PR DESCRIPTION
This all came about from trying to use `NSwag.Examples` with [Eventuous](https://eventuous.dev) command endpoints.
`NSwag.Examples` was crashing. After some investigation I found it was using a combination of minimal api and **HttpContext** as the method parameter. This was causing a **NullException**.
I ended up going down a bit of a rabbit hole, but have:

* Fixed the exception
* Fallback to using **Accepts** for request body
* Fallback to using **Produces** for return type
* Added sample app for Minimal API
